### PR TITLE
Removed notification permission

### DIFF
--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -7,11 +7,9 @@ separate-locales: false
 finish-args:
   - --share=ipc
   - --socket=x11
-  - --socket=wayland
   - --share=network
   - --device=dri
   - --talk-name=org.freedesktop.secrets
-  - --talk-name=org.freedesktop.Notifications
   - --filesystem=~/.local/state/protonmail/bridge
 modules:
   - shared-modules/libsecret/libsecret.json


### PR DESCRIPTION
Wayland socket is not needed anymore, window can be moved again. Possible fix
for #14