### PR TITLE
Update protonmail bridge to 1.6.9.

### DIFF
--- a/ch.protonmail.protonmail-bridge.metainfo.xml
+++ b/ch.protonmail.protonmail-bridge.metainfo.xml
@@ -41,6 +41,7 @@
   </screenshots>
 
   <releases>
+    <release version="1.6.9" date="2021-04-22"/>
     <release version="1.6.6" date="2021-03-04"/>
     <release version="1.6.3" date="2021-02-16">
       <p>Release Notes:</p>

--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -37,8 +37,8 @@ modules:
     sources:
       - type: file
         dest-filename: protonmail-bridge.deb
-        url: https://protonmail.com/download/protonmail-bridge_1.6.6-1_amd64.deb
-        sha256: c1319da98fa2f2ea227f80d0d2ebabb00a6d0da0ffc5df5c291764f35afd8541
+        url: https://protonmail.com/download/bridge/protonmail-bridge_1.6.9-1_amd64.deb
+        sha256: ba3917996c5df14e96086c11becc5629526cdf45e6953b6ff53afa6e1417a554
         x-checker-data:
           type: html
           url: https://protonmail.com/download/current_version_linux.json


### PR DESCRIPTION
This is a simple update of the bridge to version 1.6.9.