### PR TITLE
Fix autostart

### DIFF
--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -10,6 +10,7 @@ finish-args:
   - --share=network
   - --device=dri
   - --talk-name=org.freedesktop.secrets
+  - --filesystem=xdg-config/autostart:create
 modules:
   - libsecret.json
   - name: fake-gnome-keyring


### PR DESCRIPTION
Currently, this flatpak doesn't grant the ProtonMail Bridge the `filesystem=xdg-config/autostart` permission, which means it will only create an autostart entry in the shadow directory. This PR fixes the issue.