### PR TITLE
Switch to freedesktop runtime

### DIFF
--- a/ch.protonmail.protonmail-bridge.metainfo.xml
+++ b/ch.protonmail.protonmail-bridge.metainfo.xml
@@ -41,7 +41,7 @@
   </screenshots>
 
   <releases>
-    <release version="2.1.0-1" date="2022-02-03"/>
+    <release version="2.1.0" date="2022-02-03"/>
     <release version="1.8.12" date="2021-12-06"/>
     <release version="1.8.10" date="2021-10-13"/>
     <release version="1.8.9" date="2021-09-01"/>

--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -39,9 +39,9 @@ modules:
         url: https://protonmail.com/download/bridge/protonmail-bridge_2.1.0-1_amd64.deb
         sha256: 7d78b17558b729fa54e8b696ece17e8597f05cc7286208229d83ac6a6885fb01
         x-checker-data:
-          type: html
+          type: json
           url: https://protonmail.com/download/current_version_linux.json
-          version-pattern: protonmail-bridge_([\d.]+\d+(?:-\d+)?)_amd64.deb
-          url-template: https://protonmail.com/download/bridge/protonmail-bridge_${version}_amd64.deb
+          version-query: .Version
+          url-query: .DebFile
       - type: file
         path: ch.protonmail.protonmail-bridge.metainfo.xml

--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -1,7 +1,7 @@
 id: ch.protonmail.protonmail-bridge
-runtime: org.kde.Platform
-sdk: org.kde.Sdk
-runtime-version: '6.2'
+runtime: org.freedesktop.Platform
+sdk: org.freedesktop.Sdk
+runtime-version: '21.08'
 command: protonmail-bridge
 finish-args:
   - --share=ipc


### PR DESCRIPTION
There was a time where protonmail-bridge didn't include the required QT
bits, see 3cd089b52308ad0e1ede649eafca5bb0fa6ae014.