### PR TITLE
Update branding

### DIFF
--- a/ch.protonmail.protonmail-bridge.metainfo.xml
+++ b/ch.protonmail.protonmail-bridge.metainfo.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>ch.protonmail.protonmail-bridge</id>
-  <name>ProtonMail Bridge</name>
+  <name>Proton Mail Bridge</name>
   <project_license>GPL-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
-  <developer_name>Proton Technologies AG</developer_name>
+  <developer_name>Proton AG</developer_name>
   <url type="homepage">https://proton.me/mail/bridge</url>
   <url type="bugtracker">https://github.com/ProtonMail/proton-bridge/issues</url>
   <url type="faq">https://proton.me/support/protonmail-bridge-faq</url>
@@ -23,7 +23,7 @@
 
   <description>
     <p>
-      The ProtonMail Bridge is an application for paid users that runs on your computer in the background and seamlessly encrypts and decrypts your mail as it enters and leaves your computer. It allows for full integration of your ProtonMail account with any program that supports IMAP and SMTP such as Microsoft Outlook, Mozilla Thunderbird and Apple Mail.
+      The Proton Mail Bridge is an application for paid users that runs on your computer in the background and seamlessly encrypts and decrypts your mail as it enters and leaves your computer. It allows for full integration of your Proton Mail account with any program that supports IMAP and SMTP such as Microsoft Outlook, Mozilla Thunderbird and Apple Mail.
     </p>
   </description>
 


### PR DESCRIPTION
Proton Technologies AG changed their name to Proton AG.  In addition, they have renamed all their products to be more consistent.  ProtonMail has now changed to two words, Proton Mail.

URL: https://proton.me/blog/evolving-privacy