### PR TITLE
Update to version 3.4.2

### DIFF
--- a/ch.protonmail.protonmail-bridge.metainfo.xml
+++ b/ch.protonmail.protonmail-bridge.metainfo.xml
@@ -44,6 +44,7 @@
   </screenshots>
 
   <releases>
+    <release version="3.4.2" date="2023-09-04"/>
     <release version="3.3.2" date="2023-07-13"/>
     <release version="3.3.0" date="2023-06-21"/>
     <release version="3.2.0" date="2023-05-26"/>

--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -50,8 +50,8 @@ modules:
     sources:
       - type: file
         dest-filename: protonmail-bridge.deb
-        url: https://proton.me/download/bridge/protonmail-bridge_3.3.2-1_amd64.deb
-        sha256: 9f7801d3e5298e9f0490762e7406947450bba2e79caf87e1c47f68b297c76c39
+        url: https://github.com/ProtonMail/proton-bridge/releases/download/v3.4.2/protonmail-bridge_3.4.2-1_amd64.deb
+        sha256: fc9e1543e720d321218d095abc03a7b293ceda49de97a0f7d13912f65ad4927b
         x-checker-data:
           type: json
           url: https://proton.me/download/current_version_linux.json


### PR DESCRIPTION
This should update the bridge to the newest software. It seems like the one on Proton's website hasn't been updated, so I switched to the GitHub releases. This could maybe also make it easier with the external data checker.