### PR TITLE
Update the external data checker to use GitHub releases

### DIFF
--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -58,5 +58,6 @@ modules:
           tag-query: ".tag_name"
           version-query: $tag | sub("^v"; "")
           timestamp-query: .published_at
+          url-query: '"https://github.com/ProtonMail/proton-bridge/releases/download/v" + $version + "/protonmail-bridge_" + $version + "-1_amd64.deb"'
       - type: file
         path: ch.protonmail.protonmail-bridge.metainfo.xml

--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -54,8 +54,9 @@ modules:
         sha256: fc9e1543e720d321218d095abc03a7b293ceda49de97a0f7d13912f65ad4927b
         x-checker-data:
           type: json
-          url: https://proton.me/download/current_version_linux.json
-          version-query: .Version
-          url-query: .DebFile
+          url: https://api.github.com/repos/ProtonMail/proton-bridge/releases/latest
+          tag-query: ".tag_name"
+          version-query: $tag | sub("^v"; "")
+          timestamp-query: .published_at
       - type: file
         path: ch.protonmail.protonmail-bridge.metainfo.xml


### PR DESCRIPTION
This switches the external data checker to the GitHub releases. This decision does make sense to me because it seems like the version on the website is 2 months behind, yet they still offer the in-app upgrades. So their update checker seems to track the GitHub release cycle, which means Flatpak users could be confused because they get offered upgrades that the Flatpak maintainers are not aware of yet.

However, I don't know how one would check the functionality, so I don't know if my config even works, but I tried following other project tracking GitHub releases here.