### PR TITLE
Enable the Wayland socket by default

### DIFF
--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -5,7 +5,8 @@ runtime-version: '23.08'
 command: protonmail-bridge
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --share=network
   - --device=dri
   - --talk-name=org.freedesktop.secrets


### PR DESCRIPTION
This PR enables the Wayland socket and sets x11 as fallback. I think there isn't really a reason for not doing it. I checked on a device running Wayland and a device running x11 and both work fine with this config with the upside of proper fractional scaling and the many other advantages of using native Wayland.