### PR TITLE
Update the Freedesktop SDK to the version 23.08

### DIFF
--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -1,7 +1,7 @@
 id: ch.protonmail.protonmail-bridge
 runtime: org.freedesktop.Platform
 sdk: org.freedesktop.Sdk
-runtime-version: '22.08'
+runtime-version: '23.08'
 command: protonmail-bridge
 finish-args:
   - --share=ipc


### PR DESCRIPTION
This PR updates the Freedesktop SDK to the new 23.08 version. Pretty self-explanatory. This will be the last PR for now. I'm sorry for the spam, but this way it's possible to merge them individually. :)