### PR TITLE
Fix Update Checker

### DIFF
--- a/ch.protonmail.protonmail-bridge.metainfo.xml
+++ b/ch.protonmail.protonmail-bridge.metainfo.xml
@@ -44,6 +44,7 @@
   </screenshots>
 
   <releases>
+    <release version="3.6.1" date="2023-11-01"/>
     <release version="3.5.4" date="2023-10-19"/>
     <release version="3.5.3" date="2023-10-12"/>
     <release version="3.4.2" date="2023-09-04"/>

--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -51,15 +51,12 @@ modules:
     sources:
       - type: file
         dest-filename: protonmail-bridge.deb
-        url: https://github.com/ProtonMail/proton-bridge/releases/download/v3.5.4/protonmail-bridge_3.5.4-1_amd64.deb
-        sha256: 2de6162e3a7b300fb3c36d6cc09937fe7dbee33bd2bcc8779c226e518e4ad382
+        url: https://proton.me/download/bridge/protonmail-bridge_3.6.1-2_amd64.deb
+        sha256: 59c75d5023ba97447d45e8d5f0c1dda14a2c298714ebd39813a50cbc4b27f400
         x-checker-data:
           type: json
-          url: https://api.github.com/repos/ProtonMail/proton-bridge/releases/latest
-          tag-query: .tag_name
-          version-query: $tag | sub("^v"; "")
-          timestamp-query: .published_at
-          url-query: '"https://github.com/ProtonMail/proton-bridge/releases/download/v"
-            + $version + "/protonmail-bridge_" + $version + "-1_amd64.deb"'
+          url: https://proton.me/download/current_version_linux.json
+          version-query: .Version
+          url-query: .DebFile
       - type: file
         path: ch.protonmail.protonmail-bridge.metainfo.xml


### PR DESCRIPTION
- The latest stable version is 3.6.1-2 instead of 3.6.1-1, which does not match the current checker URL template
- Update to version 3.6.1-2