### PR TITLE
fix: manifest typos, missing cleanup sections, and stale screenshot caption

### DIFF
--- a/ch.protonmail.protonmail-bridge.metainfo.xml
+++ b/ch.protonmail.protonmail-bridge.metainfo.xml
@@ -39,13 +39,13 @@
       <image type="source">
         https://github.com/flathub/ch.protonmail.protonmail-bridge/raw/master/screenshots/bridge.png
       </image>
-      <caption>ProtonMail Bridge main screen.</caption>
+      <caption>Proton Mail Bridge main screen.</caption>
     </screenshot>
     <screenshot>
       <image type="source">
         https://github.com/flathub/ch.protonmail.protonmail-bridge/raw/master/screenshots/bridge-conf.png
       </image>
-      <caption>ProtonMail Bridge Settings screen.</caption>
+      <caption>Proton Mail Bridge Settings screen.</caption>
     </screenshot>
   </screenshots>
 

--- a/ch.protonmail.protonmail-bridge.yaml
+++ b/ch.protonmail.protonmail-bridge.yaml
@@ -17,7 +17,7 @@ modules:
     config-opts:
       - --localstatedir=/var/lib
       - --sbindir=${FLATPAK_DEST}/bin
-      - --disable-stati
+      - --disable-static
       - --disable-rpath
     cleanup:
       - /bin
@@ -25,7 +25,7 @@ modules:
       - /lib/pkgconfig
       - /share/et
       - /share/examples
-      - /share/ma
+      - /share/man
     sources:
       - type: archive
         url: https://github.com/krb5/krb5/archive/refs/tags/krb5-1.22.1-final.tar.gz
@@ -36,6 +36,11 @@ modules:
           - autoreconf -si
   - name: libcbor
     buildsystem: cmake
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
+      - /lib/*.a
     sources:
       - type: git
         url: https://github.com/PJK/libcbor
@@ -43,6 +48,16 @@ modules:
         commit: 9826a4315116a588f7416912db9da6fcecd8da11
   - name: libfido2
     buildsystem: cmake
+    config-opts:
+      - -DBUILD_TESTS=OFF
+      - -DBUILD_EXAMPLES=OFF
+      - -DBUILD_MANPAGES=OFF
+      - -DBUILD_TOOLS=OFF
+      - -DBUILD_STATIC_LIBS=OFF
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /lib/cmake
     sources:
       - type: git
         url: https://github.com/Yubico/libfido2


### PR DESCRIPTION
Fix manifest bugs and a stale screenshot caption. No functional behaviour is changed; the installed application is identical.

### `ch.protonmail.protonmail-bridge.yaml`

**Bug fixes**
- `--disable-stati` → `--disable-static` in the krb5 `config-opts`. Autoconf accepted the abbreviation only because no other option started with `stati`, making it fragile against future krb5 releases.
- `/share/ma` → `/share/man` in the krb5 `cleanup` list. The truncated path matched nothing, silently leaving krb5 man pages in the bundle.

**Bundle size / build hygiene**
- Added `cleanup` sections to `libcbor` and `libfido2`; neither had one, so their headers, pkg-config files, cmake config files, and static libraries were all leaking into the final Flatpak.
- Added `config-opts` to `libfido2` to disable building tests, examples, man pages, tools, and the static library at compile time, since none of these are needed at runtime.

### `ch.protonmail.protonmail-bridge.metainfo.xml`

- Fixed screenshot captions: `ProtonMail Bridge` → `Proton Mail Bridge` to match the current branding used in the `<name>` element and throughout the rest of the file.

### Testing

- `flatpak-builder --show-deps`: no manifest warnings 
- `flatpak-builder --download-only`: all four sources (krb5 archive, libcbor git, libfido2 git, upstream `.deb`) downloaded and checksums verified 